### PR TITLE
Allow other modules to alter payment event data.

### DIFF
--- a/campaignion_logcrm.api.php
+++ b/campaignion_logcrm.api.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Document hooks invoked by this module.
+ *
+ * Code in this file is only for documentation purposes. It's never executed.
+ */
+
+/**
+ * Allow other modules to modify the event data for payment events.
+ *
+ * @param array $data
+ *   Original event data array.
+ * @param \Payment $payment
+ *   The payment object for which we do generate data.
+ */
+function hook_campaignion_logcrm_payment_event_data_alter(array &$data, Payment $payment) {
+  $data['tax'] = $payment->totalAmount(TRUE) - $payment->totalAmount(FALSE);
+}

--- a/src/Event.php
+++ b/src/Event.php
@@ -32,6 +32,8 @@ class Event {
     $data['method_specific'] = $payment->method->title_specific;
     $data['method_generic'] = $payment->method->title_generic;
     $data['controller'] = $payment->method->controller->name;
+    // Let other modules alter the data.
+    drupal_alter('campaignion_logrcm_payment_event_data', $data, $payment);
     return new static($type, $status->created, $data);
   }
 


### PR DESCRIPTION
Needed to add payment specific data for braintree_payment in this case.