### PR TITLE
Add submitted & completed date to the submission events

### DIFF
--- a/src/SubmissionExporter.php
+++ b/src/SubmissionExporter.php
@@ -78,6 +78,8 @@ class SubmissionExporter {
         $data[$component['form_key']] = $value;
       }
     }
+    $data['_submitted_at'] = date(DATE_ISO8601, $submission->submitted);
+    $data['_completed_at'] = isset($submission->completed) ? date(DATE_ISO8601, $submission->completed) : NULL;
     $data['action'] = $this->actionData($submission);
     $data['uuid'] = $submission->uuid;
     $data['is_draft'] = (bool) $submission->is_draft;

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -53,6 +53,7 @@ class EventTest extends \DrupalUnitTestCase {
       'is_draft' => 0,
       'uuid' => 'test-uuid',
       'submitted' => 1445948845,
+      'completed' => 1445948846,
       'tracking' => (object) [
         'tags' => [],
       ],
@@ -141,6 +142,8 @@ class EventTest extends \DrupalUnitTestCase {
           'ip_address' => '127.0.0.1',
         ],
       ],
+      '_submitted_at' => '2015-10-27T12:27:25+0000',
+      '_completed_at' => '2015-10-27T12:27:26+0000',
     ], $a);
   }
 


### PR DESCRIPTION
This adds a new attribute `_completed_at` to the form submission events.