### PR TITLE
Payment data based on $controller->webformData()

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   phpunit:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions: ["7.3", "7.4"]
@@ -25,6 +25,7 @@ jobs:
       run: |
         sudo systemctl start mysql
         mysql -e 'CREATE DATABASE ${{ env.DB_DATABASE }};' -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
+        mysql -e "ALTER USER '${{ env.DB_USER }}'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root';" -u${{ env.DB_USER }} -p${{ env.DB_PASSWORD }}
     - name: Set env
       run: |
         echo "REPO=`pwd`" >> $GITHUB_ENV

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,8 +51,8 @@ jobs:
         ln -s $REPO $ROOT/sites/all/modules/module_under_test
         cd $ROOT
         curl https://www.drupal.org/files/issues/1891356-drupal_static_reset-on-module-changes-30-D7.patch | patch -p1
-        drush dl campaignion-7.x-2.20 i18n libraries little_helpers-2.0-alpha11 ultimate_cron webform_paymethod_select webform_submission_uuid xautoload
-        drush --yes pm-enable campaignion_logcrm campaignion_newsletters campaignion_supporter_tags campaignion_source_tags wps_test_method
+        drush dl campaignion-7.x-2.20 i18n libraries little_helpers-2.0-alpha11 manual_direct_debit ultimate_cron webform_paymethod_select webform_submission_uuid xautoload
+        drush --yes pm-enable campaignion_logcrm campaignion_newsletters campaignion_supporter_tags campaignion_source_tags manual_direct_debit_uk wps_test_method
     - name: Run phpunit tests
       run: UPAL_ROOT=$ROOT UPAL_WEB_URL=http://127.0.0.1 XDEBUG_MODE=coverage phpunit --bootstrap=$COMPOSER_HOME/vendor/torotil/upal/bootstrap.php --coverage-clover=coverage.xml .
     - uses: codecov/codecov-action@v1

--- a/src/PaymentExporter.php
+++ b/src/PaymentExporter.php
@@ -24,7 +24,11 @@ class PaymentExporter {
     $data['status'] = $status->status;
     $data['method_specific'] = $payment->method->title_specific;
     $data['method_generic'] = $payment->method->title_generic;
-    $data['controller'] = $payment->method->controller->name;
+    $controller = $payment->method->controller;
+    $data['controller'] = $controller->name;
+    if (webform_paymethod_select_implements_data_interface($controller)) {
+      $data['payment_data'] = $controller->webformData($payment);
+    }
     return $data;
   }
 

--- a/tests/PaymentExporterTest.php
+++ b/tests/PaymentExporterTest.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\campaignion_logcrm;
 
+use Drupal\manual_direct_debit_uk\AccountDataController;
 use Drupal\wps_test_method\DummyController;
 use Upal\DrupalUnitTestCase;
 
@@ -39,6 +40,65 @@ class PaymentExporterTest extends DrupalUnitTestCase {
       'method_specific' => 'Dummy method',
       'method_generic' => 'Test payment method',
       'controller' => 'controller_machine_name',
+    ], $data);
+  }
+
+  /**
+   * Test exporting payment data of a manual_direct_debit_uk payment.
+   */
+  public function testExportManualDirectDebit() {
+    $payment = entity_create('payment', [
+      'pid' => 42,
+      'currency_code' => 'EUR',
+      'method' => entity_create('payment_method', [
+        'title_specific' => 'Dummy method',
+        'title_generic' => 'Test payment method',
+        'controller' => new AccountDataController(),
+      ]),
+    ]);
+    $payment->method->controller->name = '\\Drupal\\manual_direct_debit_uk\\AccountDataController';
+    $payment->setLineItem(new \PaymentLineItem([
+      'name' => 'foo',
+      'quantity' => 2,
+      'amount' => 3.5,
+    ]));
+    $payment->method_data = [
+      'holder' => 'Account holder name',
+      'country' => 'GB',
+      'iban' => 'no-iban',
+      'bic' => 'no-bic',
+      'account' => '31926819',
+      'bank_code' => '601613',
+      'payment_date' => '15',
+    ];
+    $exporter = new PaymentExporter();
+    $data = $exporter->toJson($payment);
+    drupal_alter('campaignion_logcrm_payment_event_data', $data, $payment);
+    $this->assertEqual([
+      'pid' => 42,
+      'currency_code' => 'EUR',
+      'total_amount' => 7.0,
+      'status' => 'payment_status_new',
+      'method_specific' => 'Dummy method',
+      'method_generic' => 'Test payment method',
+      'controller' => '\\Drupal\\manual_direct_debit_uk\\AccountDataController',
+      // Implementation in PaymentExporter based $controller->webformData().
+      'payment_data' => [
+        'account_holder' => 'Account holder name',
+        'account_country' => 'GB',
+        'account_iban' => 'no-iban',
+        'account_bic' => 'no-bic',
+        'account_number' => '31926819',
+        'account_bank_code' => '601613',
+        'account_payment_date' => '15',
+      ],
+      // From hook_campaignion_logcrm_payment_event_data_alter().
+      'account' => [
+        'holder' => 'Account holder name',
+        'number' => '31926819',
+        'sort_code' => '601613',
+        'payment_date' => '15',
+      ],
     ], $data);
   }
 


### PR DESCRIPTION
This adds a `$data['payment_data']` dictionary that is based on the data that otherwise could be downloaded as CSV.

Design choices made:

- Use the data directly from the payment controller. All changes / optimizations of the payment data would have to happen there.
- Leave the existing alter hooks untouched so that we keep backwards compatibility. Perhaps we should deprecate them.