### PR TITLE
Move webform hooks to be called after all others

### DIFF
--- a/campaignion_logcrm.module
+++ b/campaignion_logcrm.module
@@ -37,6 +37,17 @@ if (module_exists('campaignion_source_tags')) {
 }
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function campaignion_logcrm_module_implements_alter(array &$impl, $hook) {
+  if ($hook == 'webform_submission_insert' || $hook == 'webform_submission_update') {
+    $group = $impl['campaignion_logcrm'];
+    unset($impl['campaignion_logcrm']);
+    $impl['campaignion_logcrm'] = $group;
+  }
+}
+
+/**
  * Implements hook_cronapi().
  */
 function campaignion_logcrm_cronapi($op, $job = NULL) {


### PR DESCRIPTION
Some modules like webform_tracking add their data to the $submission object in hook_webform_submission_insert/update() so it only available after their implementations have been called.