### PR TITLE
Forward compatibility for form submissions

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -6,6 +6,9 @@ use Drupal\little_helpers\Services\Container;
 use Drupal\little_helpers\Webform\Submission;
 
 class Event {
+
+  const VERSION = '1.1.0';
+
   public $type;
   public $date;
   public $data;
@@ -50,6 +53,7 @@ class Event {
     return [
       'type' => $this->type,
       'date' => date('c', $d),
+      'version' => static::VERSION,
     ] + $this->data;
   }
 }

--- a/src/SubmissionExporter.php
+++ b/src/SubmissionExporter.php
@@ -71,11 +71,13 @@ class SubmissionExporter {
    *   JSON serializable data representing the submission.
    */
   public function data(Submission $submission) {
-    $data = [];
+    $data['version'] = '1.0';
+    $data['data'] = [];
     foreach ($submission->node->webform['components'] as $cid => $component) {
       $exporter = $this->loader->loadService($component['type'], FALSE) ?: $this->loader->loadService('verbatim');
       if ($value = $exporter->value($component, $submission)) {
         $data[$component['form_key']] = $value;
+        $data['data'][$component['form_key']] = $value;
       }
     }
     $data['_submitted_at'] = date(DATE_ISO8601, $submission->submitted);
@@ -94,6 +96,11 @@ class SubmissionExporter {
       'submission' => url("node/$nid/submission/{$submission->sid}", $link_options),
     ];
     $data['_optins'] = $this->optInExporter->export($submission);
+    foreach (['submitted_at', 'completed_at', 'links', 'optins'] as $key) {
+      if (!isset($data[$key]) && isset($data["_$key"])) {
+        $data[$key] = $data["_$key"];
+      }
+    }
     return $data;
   }
 

--- a/src/SubmissionExporter.php
+++ b/src/SubmissionExporter.php
@@ -71,7 +71,6 @@ class SubmissionExporter {
    *   JSON serializable data representing the submission.
    */
   public function data(Submission $submission) {
-    $data['version'] = '1.0';
     $data['data'] = [];
     foreach ($submission->node->webform['components'] as $cid => $component) {
       $exporter = $this->loader->loadService($component['type'], FALSE) ?: $this->loader->loadService('verbatim');

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -35,6 +35,7 @@ class EventTest extends \DrupalUnitTestCase {
         ],
       ],
       5 => ['type' => 'email', 'form_key' => 'email'],
+      6 => ['type' => 'text', 'form_key' => 'tracking'],
     ];
     MockSubmission::prepareComponents($node);
     node_save($node);
@@ -87,6 +88,7 @@ class EventTest extends \DrupalUnitTestCase {
       3 => [NULL],
       4 => ['radios:opt-in'],
       5 => ['test@example.com'],
+      6 => ['overridden by tracking'],
     ];
 
     $e = Event::fromSubmission($submission);
@@ -139,6 +141,7 @@ class EventTest extends \DrupalUnitTestCase {
         'number' => 57,
         'email' => 'test@example.com',
         'email_opt_in' => 'radios:opt-in',
+        'tracking' => 'overridden by tracking',
       ],
     ];
     foreach (['completed_at', 'submitted_at', 'links', 'optins'] as $key) {

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -94,12 +94,9 @@ class EventTest extends \DrupalUnitTestCase {
     unset($a['date']);
     $nid = $submission->node->nid;
     $link_options = ['absolute' => TRUE, 'alias' => FALSE];
-    $this->assertEquals([
+    $expected_data = [
+      'version' => '1.0',
       'is_draft' => FALSE,
-      'text' => 'TestText',
-      'number' => 57,
-      'email' => 'test@example.com',
-      'email_opt_in' => 'radios:opt-in',
       'uuid' => 'test-uuid',
       'type' => 'form_submission',
       'action' => [
@@ -115,12 +112,12 @@ class EventTest extends \DrupalUnitTestCase {
       'tracking' => (object) [
         'tags' => [],
       ],
-      '_links' => [
+      'links' => [
         'action' => url("node/$nid", $link_options),
         'action_pretty_url' => url("node/$nid", ['alias' => TRUE] + $link_options),
         'submission' => url("node/$nid/submission/{$submission->sid}", $link_options),
       ],
-      '_optins' => [
+      'optins' => [
         4 => [
           'address' => 'test@example.com',
           'operation' => 'opt-in',
@@ -135,9 +132,20 @@ class EventTest extends \DrupalUnitTestCase {
           'ip_address' => '127.0.0.1',
         ],
       ],
-      '_submitted_at' => '2015-10-27T12:27:25+0000',
-      '_completed_at' => '2015-10-27T12:27:26+0000',
-    ], $a);
+      'submitted_at' => '2015-10-27T12:27:25+0000',
+      'completed_at' => '2015-10-27T12:27:26+0000',
+      'data' => [
+        'text' => 'TestText',
+        'number' => 57,
+        'email' => 'test@example.com',
+        'email_opt_in' => 'radios:opt-in',
+      ],
+    ];
+    foreach (['completed_at', 'submitted_at', 'links', 'optins'] as $key) {
+      $expected_data["_$key"] = $expected_data[$key];
+    }
+    $expected_data += $expected_data['data'];
+    $this->assertEquals($expected_data, $a);
   }
 
 }

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -73,6 +73,7 @@ class EventTest extends \DrupalUnitTestCase {
     unset($d['date']);
     $this->assertEquals([
       'type' => 'form_submission_confirmed',
+      'version' => '1.1.0',
       'uuid' => 'test-uuid',
     ], $d);
   }
@@ -97,7 +98,7 @@ class EventTest extends \DrupalUnitTestCase {
     $nid = $submission->node->nid;
     $link_options = ['absolute' => TRUE, 'alias' => FALSE];
     $expected_data = [
-      'version' => '1.0',
+      'version' => '1.1.0',
       'is_draft' => FALSE,
       'uuid' => 'test-uuid',
       'type' => 'form_submission',


### PR DESCRIPTION
Copies the form data to where it’s expected in IST 2.0:

- submitted values in `data`
- All underscore prefixed values without underscore

Todos:

- [x] Test for a form-key that is overridden by a built-in value