### PR TITLE
OptInExporter: Avoid sending null-lists

### DIFF
--- a/src/OptInExporter.php
+++ b/src/OptInExporter.php
@@ -97,9 +97,13 @@ class OptInExporter {
         $opt_in['unsubscribe_unknown'] = variable_get_value('campaignion_newsletters_unsubscribe_unknown');
         $opt_in['trigger_opt_in_email'] = empty($component['extra']['opt_in_implied']);
         $opt_in['trigger_welcome_email'] = !empty($component['extra']['send_welcome']);
-        $opt_in['lists'] = array_values(array_map(function ($list_id) use ($list_identifiers) {
-          return $list_identifiers[$list_id];
-        }, $component['extra']['lists']));
+        $opt_in['lists'] = array_map(function ($list_id) use ($list_identifiers) {
+          return $list_identifiers[$list_id] ?? NULL;
+        }, $component['extra']['lists']);
+        // Remove lists that could not be mapped: Webform component is referencing a deleted list.
+        $opt_in['lists'] = array_filter($opt_in['lists']);
+        // Make this an indexed array so that it will be JSON encoded as array.
+        $opt_in['lists'] = array_values($opt_in['lists']);
         $opt_in['ip_address'] = $this->ipAddress;
       }
     }

--- a/tests/OptInExporterTest.php
+++ b/tests/OptInExporterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\campaignion_logcrm;
+
+use Drupal\campaignion_opt_in\Values;
+use Drupal\little_helpers\Webform\Submission;
+use Upal\DrupalUnitTestCase;
+
+/**
+ * Test exporting opt-ins.
+ */
+class OptInExporterTest extends DrupalUnitTestCase {
+
+  /**
+   * Test exporting opt-ins.
+   */
+  public function testExport() {
+    $submission = $this->createMock(Submission::class);
+    $s['opt_in'] = $this->createMock(Values::class);
+    $submission->method('__isset')->will($this->returnCallback(function ($prop) use ($s) {
+      return isset($s[$prop]);
+    }));
+    $submission->method('__get')->will($this->returnCallback(function ($prop) use ($s) {
+      return $s[$prop];
+    }));
+    $submission->opt_in->expects($this->any())->method('values')->willReturn([
+      1 => [
+        'value' => 'opt-in',
+        'raw_value' => 'radios:opt-in',
+        'channel' => 'email',
+      ],
+      2 => [
+        'value' => 'opt-out',
+        'raw_value' => 'checkbox:opt-out',
+        'channel' => 'post',
+      ],
+    ]);
+    $node = (object) [];
+    $node->webform['components'][1]['extra'] = [
+      'lists' => ['1' => '1', '2' => '2'],
+    ];
+    $submission->node = $node;
+    $submission->method('valueByKey')->with($this->equalTo('email'))->willReturn('test@example.com');
+    $exporter = new OptInExporter([1 => 'known-list'], '1.1.1.1');
+    $this->assertEqual([
+      1 => [
+        'operation' => 'opt-in',
+        'value' => 'radios:opt-in',
+        'channel' => 'email',
+        'address' => 'test@example.com',
+        'unsubscribe_all' => FALSE,
+        'unsubscribe_unknown' => FALSE,
+        'trigger_opt_in_email' => TRUE,
+        'trigger_welcome_email' => FALSE,
+        'lists' => ['known-list'],
+        'ip_address' => '1.1.1.1',
+      ],
+      2 => [
+        'operation' => 'opt-out',
+        'value' => 'checkbox:opt-out',
+        'channel' => 'post',
+      ],
+    ], $exporter->export($submission));
+  }
+
+}


### PR DESCRIPTION
When a webform component referenced a newsletter list that had been deleted this would lead to a `NULL` value being submitted instead of the `$list->identifier`.